### PR TITLE
Add tags and description parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ $ vagrant sakura-list-id
 - ``disk_source_archive`` - サーバで利用するディスクのベースとするアーカイブ
 - ``server_name`` - サーバ名
 - ``server_plan`` - 作成するサーバのプラン ID
+- ``tags`` - 作成するサーバ/ディスクのタグ(リスト)
+- ``description`` - 作成するサーバ/ディスクの説明
 - ``sshkey_id`` - サーバへのログインに利用する SSH 公開鍵のリソース ID
 - ``zone_id`` - ゾーン ID (石狩第1=`is1a`, 石狩第2=`is1b`、東京第1=`tk1a`)
 

--- a/lib/vagrant-sakura/action/run_instance.rb
+++ b/lib/vagrant-sakura/action/run_instance.rb
@@ -24,12 +24,16 @@ module VagrantPlugins
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
           use_insecure_key = env[:machine].provider_config.use_insecure_key
+          tags = env[:machine].provider_config.tags
+          description = env[:machine].provider_config.description
 
           env[:ui].info(I18n.t("vagrant_sakura.creating_instance"))
           env[:ui].info(" -- Server Name: #{server_name}")
           env[:ui].info(" -- Server Plan: #{server_plan}")
           env[:ui].info(" -- Disk Plan: #{disk_plan}")
           env[:ui].info(" -- Disk Source Archive: #{disk_source_archive}")
+          env[:ui].info(" -- Tags: #{tags}") unless tags.empty?
+          env[:ui].info(" -- Description: \"#{description}\"") unless description.empty?
 
           api = env[:sakura_api]
 
@@ -44,7 +48,9 @@ module VagrantPlugins
                 "Connection" => "virtio",
                 "SourceArchive" => {
                   "ID" => disk_source_archive
-                }
+                },
+                "Tags" => tags,
+                "Description" => description
               }
             }
             response = api.post("/disk", data)
@@ -76,7 +82,9 @@ module VagrantPlugins
               "ServerPlan" => { "ID" => server_plan },
               "ConnectedSwitches" => [
                 { "Scope" => "shared", "BandWidthMbps" => 100 }
-              ]
+              ],
+              "Tags" => tags,
+              "Description" => description
             }
           }
           response = api.post("/server", data)

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -56,6 +56,16 @@ module VagrantPlugins
       # The ID of the zone.
       attr_accessor :zone_id
 
+      # The tags of the server and disk.
+      #
+      # @return [Array<String>]
+      attr_accessor :tags
+
+      # The description of the server and disk.
+      #
+      # @return [String]
+      attr_accessor :description
+
       def initialize
         @access_token        = UNSET_VALUE
         @access_token_secret = UNSET_VALUE
@@ -68,6 +78,8 @@ module VagrantPlugins
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
         @zone_id             = UNSET_VALUE
+        @tags                = UNSET_VALUE
+        @description         = UNSET_VALUE
       end
 
       def finalize!
@@ -108,6 +120,13 @@ module VagrantPlugins
         if @zone_id == UNSET_VALUE
           @zone_id = "is1a"  # the first zone
         end
+
+        @tags = [] if @tags == UNSET_VALUE
+        @tags = [@tags] unless @tags.is_a?(Array)
+        @tags.map!(&:to_s)
+
+        @description = "" if @description == UNSET_VALUE
+        @description = @description.to_s
       end
 
       def validate(machine)


### PR DESCRIPTION
Hi @tsahara,

This PR add `tags` and `description` parameter(to fix #7).  
To use these parameters, do the following:

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "dummy"
  config.ssh.username = "ubuntu"

  config.vm.provider :sakura do |sakura|
    sakura.use_insecure_key = true
    # tags
    sakura.tags = "tag1"
    # tags(multiple)
    #sakura.tags = ["tag1", "tag2"]

    # description
    sakura.description = "put description here"
  end
end
```

`tags` and `description` are apply to `server` and `disk`.