### PR TITLE
Set User-Agent header

### DIFF
--- a/lib/vagrant-sakura/driver/api.rb
+++ b/lib/vagrant-sakura/driver/api.rb
@@ -49,6 +49,7 @@ module VagrantPlugins
 
         def do_request(request)
           request.basic_auth @access_token, @access_token_secret
+          request['User-Agent'] = "vagrant-sakura/v#{VagrantPlugins::Sakura::VERSION}"
           response = @https.request(request)
           @logger.debug("#{request.method} #{request.path} #{request.body} "+
                         "=> #{response.code} : #{response.body}")


### PR DESCRIPTION
When calling the Sakura Cloud API, specify `User-Agent` header.