### PR TITLE
環境変数(SAKURACLOUD_*)からのAPIキー設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :development do
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v2.1.2'
+  gem "test-unit", "~> 3.2.3"
 end
 
 group :plugins do

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -85,10 +85,12 @@ module VagrantPlugins
       def finalize!
         if @access_token == UNSET_VALUE
           @access_token = ENV['SAKURA_ACCESS_TOKEN']
+          @access_token = ENV['SAKURACLOUD_ACCESS_TOKEN'] if @access_token.nil?
         end
 
         if @access_token_secret == UNSET_VALUE
           @access_token_secret = ENV['SAKURA_ACCESS_TOKEN_SECRET']
+          @access_token_secret = ENV['SAKURACLOUD_ACCESS_TOKEN_SECRET'] if @access_token_secret.nil?
         end
 
         if @disk_id == UNSET_VALUE
@@ -118,7 +120,8 @@ module VagrantPlugins
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
 
         if @zone_id == UNSET_VALUE
-          @zone_id = "is1b"  # the first zone
+          @zone_id = ENV['SAKURACLOUD_ZONE']
+          @zone_id = "is1b" if @zone_id.nil?
         end
 
         @tags = [] if @tags == UNSET_VALUE

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,0 +1,104 @@
+require 'test/unit'
+require "vagrant-sakura/config"
+
+module VagrantPlugins
+  module Sakura
+    class TestConfig < Test::Unit::TestCase
+
+      def setup
+        %w("SAKURACLOUD_ACCESS_TOKEN" "SAKURACLOUD_ACCESS_TOKEN_SECRET" "SAKURACLOUD_ZONE").map do |k|
+          ENV.delete(k)
+        end
+      end
+
+      def test_apikeys
+        cases = {
+            "config only" => {
+                "config" => {
+                    "access_token" => "foo",
+                    "access_token_secret" => "bar"
+                },
+                "env" => {},
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "is1b"
+                }
+            },
+            "env(SAKURA_*) only" => {
+                "config" => {},
+                "env" => {
+                    "SAKURA_ACCESS_TOKEN" => "foo",
+                    "SAKURA_ACCESS_TOKEN_SECRET" => "bar",
+                },
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "is1b"
+                }
+            },
+            "env(SAKURACLOUD_*) only" => {
+                "config" => {},
+                "env" => {
+                    "SAKURACLOUD_ACCESS_TOKEN" => "foo",
+                    "SAKURACLOUD_ACCESS_TOKEN_SECRET" => "bar",
+                    "SAKURACLOUD_ZONE" => "tk1a",
+                },
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
+            },
+            "env order" => {
+                "config" => {},
+                "env" => {
+                    "SAKURA_ACCESS_TOKEN" => "foo",
+                    "SAKURA_ACCESS_TOKEN_SECRET" => "bar",
+                    "SAKURACLOUD_ACCESS_TOKEN" => "not_use",
+                    "SAKURACLOUD_ACCESS_TOKEN_SECRET" => "not_use",
+                    "SAKURACLOUD_ZONE" => "tk1a",
+                },
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
+            },
+            "conf and env order" => {
+                "config" => {
+                    "access_token" => "foo",
+                    "access_token_secret" => "bar",
+                    "zone_id" => "tk1a"
+                },
+                "env" => {
+                    "SAKURA_ACCESS_TOKEN" => "not_use",
+                    "SAKURA_ACCESS_TOKEN_SECRET" => "not_use",
+                    "SAKURACLOUD_ACCESS_TOKEN" => "not_use",
+                    "SAKURACLOUD_ACCESS_TOKEN_SECRET" => "not_use",
+                    "SAKURACLOUD_ZONE" => "not_use",
+                },
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
+            }
+        }
+
+        cases.map {|name, c|
+          puts "Case: #{name}"
+          conf = Config.new
+          conf.set_options c["config"]
+
+          ENV.update c["env"]
+
+          conf.finalize!
+          assert_equal c["expects"]["token"], conf.access_token
+          assert_equal c["expects"]["secret"], conf.access_token_secret
+          assert_equal c["expects"]["zone"], conf.zone_id
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
(part of #15)

以下の環境変数でAPIキー/シークレット/ゾーンを指定可能とする。

- `SAKURACLOUD_ACCESS_TOKEN`
- `SAKURACLOUD_ACCESS_TOKEN_SECRET`
- `SAKURACLOUD_ZONE`

これらの環境変数は以下のsacloud配下のプロダクトと共通している。

- [sacloud/packer-builder-sakuracloud](https://github.com/sacloud/packer-builder-sakuracloud)
- [sacloud/terraform-provider-sakuracloud](https://github.com/sacloud/terraform-provider-sakuracloud)
- [sacloud/usacloud](https://github.com/sacloud/usacloud)

従来利用可能であった`SAKURA_ACCESS_TOKEN`と`SAKURA_ACCESS_TOKEN_SECRET`も利用可能。
`SAKURA_*`と`SAKURACLOUD_*`が両方指定されていた場合は`SAKURA_*`を優先する。