### PR TITLE
usacloud設定ファイルからのAPIキー読み込み

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Vagrant.configure("2") do |config|
   config.ssh.username = "ubuntu"
 
   config.vm.provider :sakura do |sakura|
-    sakura.access_token = 'YOUR ACCESS TOKEN'
-    sakura.access_token_secret = 'YOUR ACCESS TOKEN SECRET'
+    sakura.access_token = '<YOUR ACCESS TOKEN>'
+    sakura.access_token_secret = '<YOUR ACCESS TOKEN SECRET>'
     sakura.use_insecure_key = true
   end
 end
@@ -76,14 +76,55 @@ Ubuntu Server 16.04.4 LTS 64bit(石狩第2ゾーン)
 このディスクソースのログインアカウントは ``root`` ではないため、
 ``config.ssh.username`` で指定してやる必要があります。
 
-なお、さくらのクラウド API を利用するための API キー(ACCESS TOKEN)と
-シークレットトークン(ACCESS TOKEN SECRET)は環境変数
-``SAKURA_ACCESS_TOKEN`` と ``SAKURA_ACCESS_TOKEN_SECRET``で指定することも
-できます。
+## APIキーの指定
+
+さくらのクラウド API を利用するための APIキー(トークン/シークレット/ゾーン)は 以下の3通りの方法で指定できます。
+
+ 1. Vagrantfileに直接記載
+ 2. さくらのクラウド CLI [Usacloud](https://github.com/sacloud/usacloud)の設定ファイル
+ 3. 環境変数
+
+> 複数指定した場合はより上に記載されているものが優先されます。
+
+### 1. Vagrantfileに直接記載
+
+以下のようにVagrantfileに直接記載する方法です。
+
+```Ruby
+  config.vm.provider :sakura do |sakura|
+    sakura.access_token = '<YOUR ACCESS TOKEN>'
+    sakura.access_token_secret = '<YOUR ACCESS TOKEN SECRET>'
+    sakura.zone_id = '< is1a / is1b / tk1a >'
+    
+    # ...
+  end
+```
+
+### 2. さくらのクラウド CLI Usacloudの設定ファイル
+
+[Usacloud](https://github.com/sacloud/usacloud)の設定ファイルを利用する方法です。  
+デフォルトでは`~/.usacloud/<current_profile>/config.json`ファイルが利用されます。  
+Vagrantfileに`config_path`を指定することで利用する設定ファイルを指定できます。
+
+```Ruby
+  config.vm.provider :sakura do |sakura|
+    sakura.config_path = 'your/config/file.json'
+    # ...
+  end
+```
+
+### 3. 環境変数
+
+環境変数でAPIキーを指定可能です。  
+Usacloudや[Terraform for さくらのクラウド](https://github.com/sacloud/terraform-provider-sakuracloud)と共通の環境変数を利用できます。  
+
+- API アクセストークン: `SAKURACLOUD_ACCESS_TOKEN` または `SAKURA_ACCESS_TOKEN`
+- API シークレット: `SAKURACLOUD_ACCESS_TOKEN_SECRET` または `SAKURA_ACCESS_TOKEN_SECRET`
+- ゾーン: `SAKURACLOUD_ZONE`
 
 ## SSH 鍵の指定方法
 
-vagrant-sakura では、サーバにログインするための SSH 公開鍵を 3通りの方法で
+vagrant-sakura では、サーバにログインするための SSH 公開鍵を 以下の3通りの方法で
 設定できます。
 
  1. コントロールパネルで設定済みの SSH 公開鍵をリソース ID で指定する。
@@ -132,6 +173,7 @@ $ vagrant sakura-list-id
 - ``description`` - 作成するサーバ/ディスクの説明
 - ``sshkey_id`` - サーバへのログインに利用する SSH 公開鍵のリソース ID
 - ``zone_id`` - ゾーン ID (石狩第1=`is1a`, 石狩第2=`is1b`、東京第1=`tk1a`、デフォルトは`is1b`)
+- ``config_path`` - APIキーが記載されたUsacloud設定ファイルのパス
 
 ## ネットワーク
 ``vagrant-sakura`` は ``config.vm.network`` を利用したネットワークの構築を

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Ubuntu Server 16.04.4 LTS 64bit(石狩第2ゾーン)
  2. さくらのクラウド CLI [Usacloud](https://github.com/sacloud/usacloud)の設定ファイル
  3. 環境変数
 
-> 複数指定した場合はより上に記載されているものが優先されます。
+> 複数指定されている場合はより上に記載されているものが優先されます。
 
 ### 1. Vagrantfileに直接記載
 
@@ -103,8 +103,11 @@ Ubuntu Server 16.04.4 LTS 64bit(石狩第2ゾーン)
 ### 2. さくらのクラウド CLI Usacloudの設定ファイル
 
 [Usacloud](https://github.com/sacloud/usacloud)の設定ファイルを利用する方法です。  
+UsacloudにてAPIキーの設定(`usacloud config`コマンドの実行など)を行なっておけばvagrant-sakura が自動的にUsacloudの設定ファイルを読み込みます。
+この機能を利用すればVagrantfileにAPIキー関連の設定を記載する必要はありません。
+
 デフォルトでは`~/.usacloud/<current_profile>/config.json`ファイルが利用されます。  
-Vagrantfileに`config_path`を指定することで利用する設定ファイルを指定できます。
+任意のUsacloud設定ファイルを利用したい場合、Vagrantfileに`config_path`を指定することで利用する設定ファイルを指定できます。
 
 ```Ruby
   config.vm.provider :sakura do |sakura|
@@ -116,7 +119,7 @@ Vagrantfileに`config_path`を指定することで利用する設定ファイ�
 ### 3. 環境変数
 
 環境変数でAPIキーを指定可能です。  
-Usacloudや[Terraform for さくらのクラウド](https://github.com/sacloud/terraform-provider-sakuracloud)と共通の環境変数を利用できます。  
+Usacloudや[Packer for さくらのクラウド](https://github.com/sacloud/packer-builder-sakuracloud)、[Terraform for さくらのクラウド](https://github.com/sacloud/terraform-provider-sakuracloud)と共通の環境変数を利用できます。  
 
 - API アクセストークン: `SAKURACLOUD_ACCESS_TOKEN` または `SAKURA_ACCESS_TOKEN`
 - API シークレット: `SAKURACLOUD_ACCESS_TOKEN_SECRET` または `SAKURA_ACCESS_TOKEN_SECRET`

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -1,4 +1,5 @@
 require "vagrant"
+require "json"
 
 module VagrantPlugins
   module Sakura
@@ -83,13 +84,26 @@ module VagrantPlugins
       end
 
       def finalize!
+
+        usacloud_config = get_usacloud_config
+
         if @access_token == UNSET_VALUE
-          @access_token = ENV['SAKURA_ACCESS_TOKEN']
+          if usacloud_config.nil?
+            @access_token = nil
+          else
+            @access_token = usacloud_config["AccessToken"]
+          end
+          @access_token = ENV['SAKURA_ACCESS_TOKEN'] if @access_token.nil?
           @access_token = ENV['SAKURACLOUD_ACCESS_TOKEN'] if @access_token.nil?
         end
 
         if @access_token_secret == UNSET_VALUE
-          @access_token_secret = ENV['SAKURA_ACCESS_TOKEN_SECRET']
+          if usacloud_config.nil?
+            @access_token_secret = nil
+          else
+            @access_token_secret = usacloud_config["AccessTokenSecret"]
+          end
+          @access_token_secret = ENV['SAKURA_ACCESS_TOKEN_SECRET'] if @access_token_secret.nil?
           @access_token_secret = ENV['SAKURACLOUD_ACCESS_TOKEN_SECRET'] if @access_token_secret.nil?
         end
 
@@ -120,7 +134,12 @@ module VagrantPlugins
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
 
         if @zone_id == UNSET_VALUE
-          @zone_id = ENV['SAKURACLOUD_ZONE']
+          if usacloud_config.nil?
+            @zone_id = nil
+          else
+            @zone_id = usacloud_config["Zone"]
+          end
+          @zone_id = ENV['SAKURACLOUD_ZONE'] if @zone_id.nil?
           @zone_id = "is1b" if @zone_id.nil?
         end
 
@@ -147,6 +166,49 @@ module VagrantPlugins
         end
 
         { "Sakura Provider" => errors }
+      end
+
+      def choose_usacloud_profile_dir
+        profile_path = ENV.fetch("USACLOUD_PROFILE_DIR", "")
+        if profile_path.empty?
+          File.expand_path("~/.usacloud")
+        else
+          File.join(File.expand_path(profile_path), ".usacloud")
+        end
+      end
+
+      def get_usacloud_profile_name
+        profile_dir = choose_usacloud_profile_dir
+        current_file = File.join(profile_dir, "current")
+
+        return "default" unless FileTest.exist? current_file
+        File.open(current_file) do |file|
+          file.read.split("\n").each do |line|
+            return line
+          end
+        end
+        "default"
+      end
+
+      def get_usacloud_config
+        profile_dir = choose_usacloud_profile_dir
+        profile_name = get_usacloud_profile_name
+
+        return nil if profile_name.empty?
+
+        config_path = File.join(profile_dir, profile_name, "config.json")
+        if FileTest.exist?(config_path)
+          File.open(config_path) do |file|
+            begin
+              json = JSON.load(file)
+              return json
+            rescue JSON::ParserError
+              return nil
+            end
+          end
+        end
+
+        nil
       end
     end
   end

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -57,6 +57,11 @@ module VagrantPlugins
       # The ID of the zone.
       attr_accessor :zone_id
 
+      # The path of the usacloud config.
+      #
+      # @return [String]
+      attr_accessor :config_path
+
       # The tags of the server and disk.
       #
       # @return [Array<String>]
@@ -79,13 +84,14 @@ module VagrantPlugins
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
         @zone_id             = UNSET_VALUE
+        @config_path         = UNSET_VALUE
         @tags                = UNSET_VALUE
         @description         = UNSET_VALUE
       end
 
       def finalize!
 
-        usacloud_config = get_usacloud_config
+        usacloud_config = get_usacloud_config(@config_path)
 
         if @access_token == UNSET_VALUE
           if usacloud_config.nil?
@@ -190,13 +196,15 @@ module VagrantPlugins
         "default"
       end
 
-      def get_usacloud_config
-        profile_dir = choose_usacloud_profile_dir
-        profile_name = get_usacloud_profile_name
+      def get_usacloud_config(config_path = nil)
+        if config_path.nil? || config_path == UNSET_VALUE
+          profile_dir = choose_usacloud_profile_dir
+          profile_name = get_usacloud_profile_name
 
-        return nil if profile_name.empty?
+          return nil if profile_name.empty?
+          config_path = File.join(profile_dir, profile_name, "config.json")
+        end
 
-        config_path = File.join(profile_dir, profile_name, "config.json")
         if FileTest.exist?(config_path)
           File.open(config_path) do |file|
             begin

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -4,14 +4,7 @@ require "vagrant-sakura/config"
 module VagrantPlugins
   module Sakura
     class TestConfig < Test::Unit::TestCase
-
-      def setup
-        %w("SAKURACLOUD_ACCESS_TOKEN" "SAKURACLOUD_ACCESS_TOKEN_SECRET" "SAKURACLOUD_ZONE").map do |k|
-          ENV.delete(k)
-        end
-      end
-
-      def test_apikeys
+      def test_load_config
         cases = {
             "config only" => {
                 "config" => {
@@ -65,6 +58,30 @@ module VagrantPlugins
                     "zone" => "tk1a"
                 }
             },
+            "profile only" => {
+                "config" => {},
+                "env" => {},
+                "profile" => '{"AccessToken": "foo", "AccessTokenSecret": "bar", "Zone": "tk1a"}',
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
+            },
+            "conf and profile order" => {
+                "config" => {
+                    "access_token" => "foo",
+                    "access_token_secret" => "bar",
+                    "zone_id" => "tk1a"
+                },
+                "env" => {},
+                "profile" => '{"AccessToken": "not_use", "AccessTokenSecret": "not_use", "Zone": "not_use"}',
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
+            },
             "conf and env order" => {
                 "config" => {
                     "access_token" => "foo",
@@ -83,21 +100,62 @@ module VagrantPlugins
                     "secret" => "bar",
                     "zone" => "tk1a"
                 }
+            },
+            "profile and env order" => {
+                "config" => {},
+                "env" => {
+                    "SAKURA_ACCESS_TOKEN" => "not_use",
+                    "SAKURA_ACCESS_TOKEN_SECRET" => "not_use",
+                    "SAKURACLOUD_ACCESS_TOKEN" => "not_use",
+                    "SAKURACLOUD_ACCESS_TOKEN_SECRET" => "not_use",
+                    "SAKURACLOUD_ZONE" => "not_use",
+                },
+                "profile" => '{"AccessToken": "foo", "AccessTokenSecret": "bar", "Zone": "tk1a"}',
+                "expects" => {
+                    "token" => "foo",
+                    "secret" => "bar",
+                    "zone" => "tk1a"
+                }
             }
         }
 
-        cases.map {|name, c|
-          puts "Case: #{name}"
-          conf = Config.new
-          conf.set_options c["config"]
 
-          ENV.update c["env"]
+        cases.map do |name, c|
+          Dir.mktmpdir do |dir|
+            env = { "USACLOUD_PROFILE_DIR" => dir }
+            ENV.update env
 
-          conf.finalize!
-          assert_equal c["expects"]["token"], conf.access_token
-          assert_equal c["expects"]["secret"], conf.access_token_secret
-          assert_equal c["expects"]["zone"], conf.zone_id
-        }
+            %w(SAKURA_ACCESS_TOKEN SAKURACLOUD_ACCESS_TOKEN SAKURA_ACCESS_TOKEN_SECRET SAKURACLOUD_ACCESS_TOKEN_SECRET SAKURACLOUD_ZONE).map do |k|
+              ENV.delete(k)
+            end
+
+            if !c["profile"].nil?
+              current_file = File.join(dir, ".usacloud", "current")
+              FileUtils.mkdir_p(File.dirname(current_file))
+              File.open(current_file, "w") do |file|
+                file.puts "default"
+              end
+
+              profile_file = File.join(dir, ".usacloud", "default", "config.json")
+              FileUtils.mkdir_p(File.dirname(profile_file))
+              File.open(profile_file, "w") do |file|
+                file.puts c["profile"]
+              end
+            end
+
+            conf = Config.new
+            conf.set_options c["config"]
+
+            ENV.update c["env"]
+
+            conf.finalize!
+
+            assert_equal c["expects"]["token"], conf.access_token
+            assert_equal c["expects"]["secret"], conf.access_token_secret
+            assert_equal c["expects"]["zone"], conf.zone_id
+          end
+        end
+
       end
     end
   end

--- a/test/test_usacloud_config.rb
+++ b/test/test_usacloud_config.rb
@@ -1,0 +1,123 @@
+require 'test/unit'
+require "vagrant-sakura/config"
+require 'tmpdir'
+require 'fileutils'
+
+module VagrantPlugins
+  module Sakura
+    class TestUsacloudConfig < Test::Unit::TestCase
+      def setup
+        %w(SAKURACLOUD_ACCESS_TOKEN SAKURACLOUD_ACCESS_TOKEN_SECRET SAKURACLOUD_ZONE USACLOUD_PROFILE_DIR).map do |k|
+          ENV.delete(k)
+        end
+      end
+
+      def test_choose_profile_dir
+        cases = {
+            "USACLOUD_PROFILE_DIR is empty" => {
+                "env" => {"USACLOUD_PROFILE_DIR" => ""},
+                "expect" => File.expand_path("~/.usacloud")
+            },
+            "USACLOUD_PROFILE_DIR is set" => {
+                "env" => {"USACLOUD_PROFILE_DIR" => "/tmp"},
+                "expect" => "/tmp/.usacloud"
+            }
+        }
+
+        cases.map {|name, c|
+          conf = Config.new
+          ENV.update c["env"]
+
+          assert_equal c["expect"], conf.choose_usacloud_profile_dir
+        }
+
+      end
+
+      def test_get_current_profile_name
+        cases = {
+            "current file is missing" => {
+                "prepare" => false,
+                "expect" => "default"
+            },
+            "current file is empty" => {
+                "prepare" => true,
+                "profile" => "",
+                "expect" => "default"
+            },
+            "current file has valid value" => {
+                "prepare" => true,
+                "profile" => "test",
+                "expect" => "test"
+            },
+        }
+
+
+        Dir.mktmpdir do |dir|
+          env = { "USACLOUD_PROFILE_DIR" => dir }
+          ENV.update env
+
+          cases.map {|name, c|
+            conf = Config.new
+            if c["prepare"]
+              file_path = File.join(dir, ".usacloud", "current")
+              FileUtils.mkdir_p(File.dirname(file_path))
+              File.open(file_path, "w") do |file|
+                file.puts c["profile"]
+              end
+            end
+
+            assert_equal c["expect"], conf.get_usacloud_profile_name
+          }
+        end
+
+      end
+
+      def test_get_usacloud_config
+        cases = {
+            "profile is missing" => {
+                "profile_body" => nil,
+                "expect" => nil
+            },
+            "profile is invalid JSON" => {
+                "profile_body" => "Invalid JSON",
+                "expect" => nil
+            },
+            "profile has valid value" => {
+                "profile_body" => '{"AccessToken": "token", "AccessTokenSecret": "secret", "Zone": "zone"}',
+                "expect" => {
+                    "AccessToken" => "token",
+                    "AccessTokenSecret" => "secret",
+                    "Zone" => "zone",
+                }
+            },
+        }
+
+
+        Dir.mktmpdir do |dir|
+          env = { "USACLOUD_PROFILE_DIR" => dir }
+          ENV.update env
+
+          cases.map do |name, c|
+            conf = Config.new
+
+            current_file = File.join(dir, ".usacloud", "current")
+            FileUtils.mkdir_p(File.dirname(current_file))
+            File.open(current_file, "w") do |file|
+              file.puts "default"
+            end
+
+            if !c["profile_body"].nil?
+              profile_file = File.join(dir, ".usacloud", "default", "config.json")
+              FileUtils.mkdir_p(File.dirname(profile_file))
+              File.open(profile_file, "w") do |file|
+                file.puts c["profile_body"]
+              end
+            end
+
+            assert_equal c["expect"], conf.get_usacloud_config
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_usacloud_config.rb
+++ b/test/test_usacloud_config.rb
@@ -118,6 +118,47 @@ module VagrantPlugins
           end
         end
       end
+
+
+      def test_get_usacloud_config_with_path
+        cases = {
+            "config_path is invalid" => {
+                "expect" => nil
+            },
+            "config_path is valid " => {
+                "profile_body" => '{"AccessToken": "token", "AccessTokenSecret": "secret", "Zone": "zone"}',
+                "expect" => {
+                    "AccessToken" => "token",
+                    "AccessTokenSecret" => "secret",
+                    "Zone" => "zone",
+                }
+            },
+        }
+
+
+        Dir.mktmpdir do |dir|
+
+          cases.map do |name, c|
+            conf = Config.new
+            current_file = File.join(dir, ".usacloud", "current")
+            profile_file = File.join(dir, ".usacloud", "default", "config.json")
+
+            FileUtils.mkdir_p(File.dirname(current_file))
+            File.open(current_file, "w") do |file|
+              file.puts "default"
+            end
+
+            if !c["profile_body"].nil?
+              FileUtils.mkdir_p(File.dirname(profile_file))
+              File.open(profile_file, "w") do |file|
+                file.puts c["profile_body"]
+              end
+            end
+
+            assert_equal c["expect"], conf.get_usacloud_config(profile_file)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
To fix #15 

APIキー(トークン/シークレット/ゾーン)をusacloudの設定ファイルを参照して設定可能とする。
