### PR TITLE
Use TravisCI for deploying to rubygems.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 sudo: false
-
 language: ruby
-
 cache: bundler
 
 addons:
   apt:
     packages:
     - bsdtar
-
 rvm:
 - 2.3.7
 - 2.4.4
@@ -20,6 +17,13 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 script: bundle exec rake test
+
+deploy:
+  provider: rubygems
+  api_key:
+    secure: dPtjpKnaDadiUGiO/ZZG+CK0GRChirb6qbr5UawJff3X1POtU/Q7AXOfwYkMEZv55NT098jvtqPDcAA7ilqQu6Pb1YO51FnHqXk5UPqksCMcAucQX6ByL3V1X8Vliw2rbvKw8BTg9IoNotu6bDIFMDdU0Gz0iU35U9efkxIX+Rc=
+  on:
+    tags: true
 
 notifications:
   slack:


### PR DESCRIPTION
To fix #19 

rubygems.orgへのデプロイにTravisCIを利用する。