### PR TITLE
Add startup_scripts config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :development do
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v2.1.2'
   gem "test-unit", "~> 3.2.3"
+  gem "test-unit-rr", "~> 1.0.5"
   gem "rake", "~> 12.0.0"
 end
 

--- a/lib/vagrant-sakura/action/run_instance.rb
+++ b/lib/vagrant-sakura/action/run_instance.rb
@@ -24,6 +24,7 @@ module VagrantPlugins
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
           use_insecure_key = env[:machine].provider_config.use_insecure_key
+          startup_scripts = env[:machine].provider_config.startup_scripts
           tags = env[:machine].provider_config.tags
           description = env[:machine].provider_config.description
 
@@ -32,6 +33,7 @@ module VagrantPlugins
           env[:ui].info(" -- Server Plan: #{server_plan}")
           env[:ui].info(" -- Disk Plan: #{disk_plan}")
           env[:ui].info(" -- Disk Source Archive: #{disk_source_archive}")
+          env[:ui].info(" -- Startup Scripts: #{startup_scripts.map {|item| item["ID"]}}") unless startup_scripts.empty?
           env[:ui].info(" -- Tags: #{tags}") unless tags.empty?
           env[:ui].info(" -- Description: \"#{description}\"") unless description.empty?
 
@@ -39,7 +41,6 @@ module VagrantPlugins
 
           if env[:machine].provider_config.disk_id
             diskid = env[:machine].provider_config.disk_id
-
           else
             data = {
               "Disk" => {
@@ -103,7 +104,8 @@ module VagrantPlugins
           end
 
           data = {
-            "UserSubnet" => {}
+            "UserSubnet" => {},
+            "Notes" => startup_scripts
           }
           if sshkey_id
             data["SSHKey"] = { "ID" => sshkey_id }
@@ -115,6 +117,7 @@ module VagrantPlugins
           else
             raise 'failsafe'
           end
+
           response = api.put("/disk/#{diskid}/config", data)
           # Config
 

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -54,6 +54,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :use_insecure_key
 
+      # The startup script IDs of the server.
+      #
+      # @return [Array<String>]
+      attr_accessor :startup_scripts
+
       # The ID of the zone.
       attr_accessor :zone_id
 
@@ -83,6 +88,7 @@ module VagrantPlugins
         @server_plan         = UNSET_VALUE
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
+        @startup_scripts     = UNSET_VALUE
         @zone_id             = UNSET_VALUE
         @config_path         = UNSET_VALUE
         @tags                = UNSET_VALUE
@@ -138,6 +144,10 @@ module VagrantPlugins
         @sshkey_id = nil if @sshkey_id == UNSET_VALUE
 
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
+
+        @startup_scripts = [] if @startup_scripts == UNSET_VALUE
+        @startup_scripts = [@startup_scripts] unless @startup_scripts.is_a?(Array)
+        @startup_scripts.map! { |id| {"ID" => id.to_s} }
 
         if @zone_id == UNSET_VALUE
           if usacloud_config.nil?

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -157,6 +157,44 @@ module VagrantPlugins
         end
 
       end
+
+      def test_startup_scripts_handling
+        cases = {
+            "startup_scripts is empty" => {
+                "config" => {},
+                "expects" => {
+                    "startup_scripts" => []
+                }
+            },
+
+            "startup_scripts is a number" => {
+                "config" => {
+                    "startup_scripts" => 999999999999
+                },
+                "expects" => {
+                    "startup_scripts" => [{"ID" => "999999999999"}]
+                }
+            },
+
+            "startup_scripts is array" => {
+                "config" => {
+                    "startup_scripts" => [999999999999,888888888888]
+                },
+                "expects" => {
+                    "startup_scripts" => [{"ID" => "999999999999"}, {"ID" => "888888888888"}]
+                }
+            },
+        }
+
+        cases.map do |name, c|
+          conf = Config.new
+          conf.set_options c["config"]
+          conf.finalize!
+
+          assert_equal c["expects"]["startup_scripts"], conf.startup_scripts
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
To fix #26 

Vagrantfileにてスタートアップスクリプトを指定可能とする。

```rb
Vagrant.configure("2") do |config|
  # ...

  config.vm.provider :sakura do |sakura, override|
    # ...

    # スタートアップスクリプトの指定(IDで指定)
    sakura.startup_scripts = 123456789012

    # 文字列でもOK
    # sakura.startup_scripts = "123456789012"

    # 複数指定する場合
    # sakura.startup_scripts = [123456789012, xxx, yyy, ...]

  end
end
```

- 現時点ではIDでの指定に対応、名称での指定は非対応
- 指定したスタートアップスクリプトがソースアーカイブにて利用できるかのチェックは行なっていない
  (例: CentOS 7.x向けのスタートアップスクリプトをUbuntuに指定した場合など)
- 複数のスタートアップスクリプトを指定した場合の動作は未保証
  (さくらのクラウドAPI上は複数指定できるが、コントロールパネルでは一つだけ指定可能となっている)