### PR TITLE
Add packet_filter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ $ vagrant sakura-list-id
 - ``disk_source_archive`` - サーバで利用するディスクのベースとするアーカイブ
 - ``server_name`` - サーバ名
 - ``server_plan`` - 作成するサーバのプラン ID
+- ``packet_filter`` - 作成するサーバに適用するパケットフィルタ ID
 - ``startup_scripts`` - 作成するサーバに適用するスタートアップスクリプト ID(リスト)
 - ``tags`` - 作成するサーバ/ディスクのタグ(リスト)
 - ``description`` - 作成するサーバ/ディスクの説明

--- a/lib/vagrant-sakura/action/run_instance.rb
+++ b/lib/vagrant-sakura/action/run_instance.rb
@@ -24,6 +24,7 @@ module VagrantPlugins
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
           use_insecure_key = env[:machine].provider_config.use_insecure_key
+          packet_filter = env[:machine].provider_config.packet_filter.to_s
           startup_scripts = env[:machine].provider_config.startup_scripts
           tags = env[:machine].provider_config.tags
           description = env[:machine].provider_config.description
@@ -33,6 +34,7 @@ module VagrantPlugins
           env[:ui].info(" -- Server Plan: #{server_plan}")
           env[:ui].info(" -- Disk Plan: #{disk_plan}")
           env[:ui].info(" -- Disk Source Archive: #{disk_source_archive}")
+          env[:ui].info(" -- Packet Filter: #{packet_filter}") unless packet_filter.empty?
           env[:ui].info(" -- Startup Scripts: #{startup_scripts.map {|item| item["ID"]}}") unless startup_scripts.empty?
           env[:ui].info(" -- Tags: #{tags}") unless tags.empty?
           env[:ui].info(" -- Description: \"#{description}\"") unless description.empty?
@@ -93,7 +95,13 @@ module VagrantPlugins
             raise 'no Server ID returned'
           end
           env[:machine].id = serverid = response["Server"]["ID"]
+          interface_id = response["Server"]["Interfaces"][0]["ID"]
           # Server Created
+
+          unless packet_filter.empty?
+            response = api.put("/interface/#{interface_id}/to/packetfilter/#{packet_filter}")
+            # Packet Filter connected to Server
+          end
 
           begin
             response = api.put("/disk/#{diskid}/to/server/#{serverid}")

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -54,6 +54,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :use_insecure_key
 
+      # The packet filter ID of the server's first NIC.
+      #
+      # @return [String]
+      attr_accessor :packet_filter
+
       # The startup script IDs of the server.
       #
       # @return [Array<String>]
@@ -88,6 +93,7 @@ module VagrantPlugins
         @server_plan         = UNSET_VALUE
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
+        @packet_filter       = UNSET_VALUE
         @startup_scripts     = UNSET_VALUE
         @zone_id             = UNSET_VALUE
         @config_path         = UNSET_VALUE
@@ -144,6 +150,8 @@ module VagrantPlugins
         @sshkey_id = nil if @sshkey_id == UNSET_VALUE
 
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
+
+        @packet_filter = "" if @packet_filter == UNSET_VALUE
 
         @startup_scripts = [] if @startup_scripts == UNSET_VALUE
         @startup_scripts = [@startup_scripts] unless @startup_scripts.is_a?(Array)


### PR DESCRIPTION
作成するサーバに適用するパケットフィルタを指定可能にする。

```rb
Vagrant.configure("2") do |config|
  # ...

  config.vm.provider :sakura do |sakura, override|
    # ...

    # パケットフィルタの指定(IDで指定)
    sakura.packet_filter = 123456789012
  end
end
```

- 現時点ではIDでの指定に対応、名称での指定は非対応
- サーバ作成時に同時にさくらのクラウド上にパケットフィルタを登録する機能は非対応
  あらかじめコントロールパネルや[Usacloud](https://github.com/sacloud/usacloud)などで作成しておく必要があります。
- サーバの最初のNICのみが対象
  (vagrant-sakuraでは複数のNICの利用をサポートしない)
