### PR TITLE
Add os_type config

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ $ vagrant sakura-list-id
 |`centos`|`root`| - |
 |`centos6`|`root`| - |
 |`debian`|`root`| - |
-|`coreos`|`root`| - |
+|`coreos`|`core`| - |
 |`freebsd`|`root`| - |
 |`rancheros`|`rancher`| メモリ2GB以上のプランが必要 |
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,10 @@ end
 
 そして ``vagrant up --provider=sakura`` を実行してください。
 
-サーバのディスクソースを ``sakura.disk_source_archive`` で指定しなかった
-場合のデフォルトは ``113000423772`` で
-Ubuntu Server 16.04.4 LTS 64bit(石狩第2ゾーン)
-です。
+サーバのディスクソース(OS)は ``sakura.disk_source_archive`` または``sakura.os_type``で指定します。
+デフォルトでは``sakura.os_type="ubuntu"``となっています。
 
-> ※注: アーカイブのIDはゾーンごとに異なります
-
-このディスクソースのログインアカウントは ``root`` ではないため、
-``config.ssh.username`` で指定してやる必要があります。
+> 注: ディスクソースに指定するOSに応じて`config.ssh.username`を適切に指定する必要があります。詳細は`os_type`の説明を参照してください。
 
 ## APIキーの指定
 
@@ -170,7 +165,19 @@ $ vagrant sakura-list-id
 - ``access_token`` - さくらのクラウド API にアクセスするための API キー
 - ``access_token_secret`` - API キーのシークレットトークン
 - ``disk_plan`` - サーバで利用するディスクのプラン ID
-- ``disk_source_archive`` - サーバで利用するディスクのベースとするアーカイブ
+- ``os_type`` - サーバで利用するディスクのベースとするアーカイブの種別 (※ `disk_source_archive`とは同時に指定できません)  
+指定可能な値は以下の通りです。  
+
+|指定可能な値|SSHユーザー名|備考|
+|---|---|---|
+|`ubuntu`(デフォルト)|`ubuntu`| - |
+|`centos`|`root`| - |
+|`centos6`|`root`| - |
+|`debian`|`root`| - |
+|`freebsd`|`root`| - |
+|`rancheros`|`rancher`| メモリ2GB以上のプランが必要 |
+
+- ``disk_source_archive`` - サーバで利用するディスクのベースとするアーカイブのID (※`os_type`とは同時に指定できません)
 - ``server_name`` - サーバ名
 - ``server_plan`` - 作成するサーバのプラン ID
 - ``packet_filter`` - 作成するサーバに適用するパケットフィルタ ID

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ $ vagrant sakura-list-id
 |`centos`|`root`| - |
 |`centos6`|`root`| - |
 |`debian`|`root`| - |
+|`coreos`|`root`| - |
 |`freebsd`|`root`| - |
 |`rancheros`|`rancher`| メモリ2GB以上のプランが必要 |
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ end
 
 そして ``vagrant up --provider=sakura`` を実行してください。
 
-サーバのディスクソース(OS)は ``sakura.disk_source_archive`` または``sakura.os_type``で指定します。
+サーバのディスクソース(OS)は ``sakura.disk_source_archive`` または``sakura.os_type``で指定します。  
 デフォルトでは``sakura.os_type="ubuntu"``となっています。
 
-> 注: ディスクソースに指定するOSに応じて`config.ssh.username`を適切に指定する必要があります。詳細は`os_type`の説明を参照してください。
+> 注: ディスクソースに指定するOSに応じて`config.ssh.username`を適切に指定する必要があります。  
+詳細は`os_type`の説明を参照してください。
 
 ## APIキーの指定
 

--- a/lib/vagrant-sakura/action.rb
+++ b/lib/vagrant-sakura/action.rb
@@ -134,6 +134,7 @@ module VagrantPlugins
           b.use HandleBox
           b.use ConfigValidate
           b.use ConnectSakura
+          b.use CompleteArchiveId
           b.use Call, ReadState do |env, b2|
             case env[:machine_state_id]
             when :up
@@ -150,6 +151,7 @@ module VagrantPlugins
       end
 
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
+      autoload :CompleteArchiveId, action_root.join("complete_archive_id")
       autoload :ConnectSakura, action_root.join("connect_sakura")
       autoload :DeleteServer, action_root.join("delete_server")
       autoload :IsCreated, action_root.join("is_created")

--- a/lib/vagrant-sakura/action/complete_archive_id.rb
+++ b/lib/vagrant-sakura/action/complete_archive_id.rb
@@ -1,0 +1,38 @@
+require 'log4r'
+require 'vagrant-sakura/driver/api'
+require "vagrant-sakura/os_type"
+
+module VagrantPlugins
+  module Sakura
+    module Action
+      class CompleteArchiveId
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_sakura::action::complete_archive_id")
+        end
+
+        def call(env)
+          config = env[:machine].provider_config
+          if config.disk_source_mode == :os_type
+            api = env[:sakura_api]
+
+            filter = VagrantPlugins::Sakura::OSType::OS_TYPE_QUERIES[config.os_type]
+            raise 'invalid os_type' if filter.nil?
+
+            data = {
+                "Filter" => filter
+            }
+            response = api.get("/archive", data)
+            raise "os_type `#{config.os_type}` is not found" if response.nil? || response["Archives"].nil? || response["Archives"].empty?
+
+            config.disk_source_archive = response["Archives"][0]["ID"]
+          else
+            config.os_type = ""
+          end
+          @app.call(env)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-sakura/action/run_instance.rb
+++ b/lib/vagrant-sakura/action/run_instance.rb
@@ -20,6 +20,8 @@ module VagrantPlugins
           server_name ||= env[:machine].name
           server_plan = env[:machine].provider_config.server_plan
           disk_plan = env[:machine].provider_config.disk_plan
+          disk_source_mode = env[:machine].provider_config.disk_source_mode
+          os_type = env[:machine].provider_config.os_type
           disk_source_archive = env[:machine].provider_config.disk_source_archive
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
@@ -33,6 +35,7 @@ module VagrantPlugins
           env[:ui].info(" -- Server Name: #{server_name}")
           env[:ui].info(" -- Server Plan: #{server_plan}")
           env[:ui].info(" -- Disk Plan: #{disk_plan}")
+          env[:ui].info(" -- Disk Source OS Type: #{os_type}") if os_type
           env[:ui].info(" -- Disk Source Archive: #{disk_source_archive}")
           env[:ui].info(" -- Packet Filter: #{packet_filter}") unless packet_filter.empty?
           env[:ui].info(" -- Startup Scripts: #{startup_scripts.map {|item| item["ID"]}}") unless startup_scripts.empty?

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -29,6 +29,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :disk_source_archive
 
+      # The source archive os-type.
+      #
+      # @return [String]
+      attr_accessor :os_type
+
       # The pathname of the SSH public key to register on the server.
       #
       # @return [String]
@@ -88,6 +93,7 @@ module VagrantPlugins
         @disk_id             = UNSET_VALUE
         @disk_plan           = UNSET_VALUE
         @disk_source_archive = UNSET_VALUE
+        @os_type             = UNSET_VALUE
         @public_key_path     = UNSET_VALUE
         @server_name         = UNSET_VALUE
         @server_plan         = UNSET_VALUE
@@ -99,6 +105,13 @@ module VagrantPlugins
         @config_path         = UNSET_VALUE
         @tags                = UNSET_VALUE
         @description         = UNSET_VALUE
+      end
+
+      # @return one of [:disk, :archive, :os_type]
+      def disk_source_mode
+        return :disk unless @disk_id.to_s.empty?
+        return :archive unless @disk_source_archive.to_s.empty?
+        :os_type
       end
 
       def finalize!
@@ -133,8 +146,10 @@ module VagrantPlugins
           @disk_plan = 4  # SSD
         end
 
-        if @disk_source_archive == UNSET_VALUE
-          @disk_source_archive = 113000423772 # Ubuntu Server 16.04.4 LTS 64bit on is1b
+        @disk_source_archive = nil if @disk_source_archive == UNSET_VALUE
+        @os_type = nil if @os_type == UNSET_VALUE
+        if @disk_source_archive.to_s.empty? && @os_type.to_s.empty?
+          @os_type = "ubuntu"
         end
 
         @public_key_path = nil if @public_key_path == UNSET_VALUE

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -4,6 +4,9 @@ require "json"
 module VagrantPlugins
   module Sakura
     class Config < Vagrant.plugin("2", :config)
+
+      OS_TYPES = %w(centos centos6 ubuntu debian coreos rancheros freebsd)
+
       # The ACCESS TOKEN to access Sakura Cloud API.
       #
       # @return [String]
@@ -202,6 +205,10 @@ module VagrantPlugins
 
         if not (@sshkey_id or @public_key_path or @use_insecure_key)
           errors << I18n.t("vagrant_sakura.config.need_ssh_key_config")
+        end
+
+        if not OS_TYPES.include? @os_type
+          errors << I18n.t("vagrant_sakura.config.need_valid_os_type")
         end
 
         { "Sakura Provider" => errors }

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -1,11 +1,10 @@
 require "vagrant"
 require "json"
+require "vagrant-sakura/os_type"
 
 module VagrantPlugins
   module Sakura
     class Config < Vagrant.plugin("2", :config)
-
-      OS_TYPES = %w(centos centos6 ubuntu debian coreos rancheros freebsd)
 
       # The ACCESS TOKEN to access Sakura Cloud API.
       #
@@ -207,7 +206,7 @@ module VagrantPlugins
           errors << I18n.t("vagrant_sakura.config.need_ssh_key_config")
         end
 
-        if not OS_TYPES.include? @os_type
+        if not VagrantPlugins::Sakura::OSType::os_types.include? @os_type
           errors << I18n.t("vagrant_sakura.config.need_valid_os_type")
         end
 

--- a/lib/vagrant-sakura/driver/api.rb
+++ b/lib/vagrant-sakura/driver/api.rb
@@ -30,8 +30,9 @@ module VagrantPlugins
         end
 
         def get(resource, data = nil)
-          request = Net::HTTP::Get.new(@prefix + resource)
-          request.body = data.to_json if data
+          uri = URI.parse(@prefix + resource)
+          uri.query = data.to_json if data
+          request = Net::HTTP::Get.new uri.to_s
           do_request request
         end
 

--- a/lib/vagrant-sakura/os_type.rb
+++ b/lib/vagrant-sakura/os_type.rb
@@ -17,6 +17,9 @@ module VagrantPlugins
           "coreos" => {
               "Tags.Name" => [%w(current-stable distro-coreos)]
           },
+          "rancheros" => {
+              "Tags.Name" => [%w(current-stable distro-rancheros)]
+          },
           "freebsd" => {
               "Tags.Name" => [%w(current-stable distro-freebsd)]
           },

--- a/lib/vagrant-sakura/os_type.rb
+++ b/lib/vagrant-sakura/os_type.rb
@@ -1,0 +1,31 @@
+module VagrantPlugins
+  module Sakura
+    module OSType
+      OS_TYPE_QUERIES = {
+          "centos" => {
+              "Tags.Name" => [%w(current-stable distro-centos)]
+          },
+          "centos6" => {
+              "Tags.Name" => [%w(distro-centos distro-ver-6.10)]
+          },
+          "ubuntu" => {
+              "Tags.Name" => [%w(current-stable distro-ubuntu)]
+          },
+          "debian" => {
+              "Tags.Name" => [%w(current-stable distro-debian)]
+          },
+          "coreos" => {
+              "Tags.Name" => [%w(current-stable distro-coreos)]
+          },
+          "freebsd" => {
+              "Tags.Name" => [%w(current-stable distro-freebsd)]
+          },
+      }
+
+      def self.os_types
+        OS_TYPE_QUERIES.keys
+      end
+    end
+  end
+end
+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -48,3 +48,5 @@ en:
         An access token secret is required via "access_token_secret"
       need_ssh_key_config: |-
         You must set one of "sshkey_id", "pubic_key_path", or "use_insecure_key".
+      need_valid_os_type: |-
+        You must set valid os_type value.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -234,6 +234,37 @@ module VagrantPlugins
         end
       end
 
+      def test_os_type
+        cases = {
+            "os_type is valid" => {
+                "config" => {
+                    "use_insecure_key" => true,
+                    "os_type" => "ubuntu"
+                },
+                "expect" => true
+            },
+
+            "os_type is invalid" => {
+                "config" => {
+                    "use_insecure_key" => true,
+                    "os_type" => "invalid",
+                },
+                "expect" => false
+            },
+        }
+
+        cases.map do |name, c|
+          conf = Config.new
+          conf.set_options c["config"]
+          conf.finalize!
+
+          res = conf.validate(nil)
+
+          assert_equal c["expect"], res["Sakura Provider"].empty?
+        end
+      end
+
+
     end
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -195,6 +195,45 @@ module VagrantPlugins
         end
 
       end
+
+      def test_disk_source_mode
+        cases = {
+            "mode is :disk" => {
+                "config" => {
+                    "disk_id" => 999999999999
+                },
+                "expect" => :disk
+            },
+
+            "mode is :archive" => {
+                "config" => {
+                    "disk_source_archive" => 999999999999
+                },
+                "expect" => :archive
+            },
+
+            "mode is :os_type" => {
+                "config" => {
+                    "os_type" => "centos"
+                },
+                "expect" => :os_type
+            },
+
+            "mode is :os_type with defaults" => {
+                "config" => {},
+                "expect" => :os_type
+            },
+        }
+
+        cases.map do |name, c|
+          conf = Config.new
+          conf.set_options c["config"]
+          conf.finalize!
+
+          assert_equal c["expect"], conf.disk_source_mode
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
アーカイブの指定に`os_type`として以下の値を指定可能とする。

- `centos`
- `centos6`
- `ubuntu`
- `debian`
- `coreos`
- `rancheros`
- `freebsd`

`os_type`が指定されると、`disk_source_archive`パラメータに対応する最新安定板のパブリックアーカイブのIDを設定する。

`os_type`と`disk_source_archive`の同時指定は不可とする。

また、[[GH-17] デフォルトアーカイブID取得の自動化](#17) についても`os_type`にデフォルト値を設けることで対応する。

`os_type`のデフォルト値は`ubuntu`とする。

#### 利用例

```rb
# Debianを利用する場合の例
Vagrant.configure("2") do |config|
  config.vm.box = "dummy"
  config.ssh.username = "root"

  config.vm.provider :sakura do |sakura, override|
    # コピー元アーカイブとしてDebianの最新安定板を利用する
    sakura.os_type = "debian"

    sakura.public_key_path        = File.expand_path("id_rsa.pub")
    override.ssh.private_key_path = File.expand_path("id_rsa")
  end
end
```