### PR TITLE
Add sakura-reinstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ vagrant-sakura では、サーバにログインするための SSH 公開鍵を
 
 
 ## コマンド
+
+#### OSの再インストール
+
+`sakura-reinstall` コマンドを使って、ディスクに対しOSの再インストールを行うことができます。
+
+```
+$ vagrant sakura-reinstall
+...
+```
+
+#### 各種IDの一覧表示
+
 `sakura-list-id` コマンドを使って、`Vagrantfile` で指定するリソース ID
 を調べることができます。
 ```

--- a/lib/vagrant-sakura/action.rb
+++ b/lib/vagrant-sakura/action.rb
@@ -35,6 +35,27 @@ module VagrantPlugins
         end
       end
 
+      def self.action_reinstall
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectSakura
+          b.use CompleteArchiveId
+          b.use Call, ReadState do |env, b2|
+            case env[:machine_state_id]
+            when :up
+              b2.use Halt
+              b2.use Reinstall
+              b2.use Provision
+            when :down, :cleaning
+              b2.use Reinstall
+              b2.use Provision
+            when :not_created
+              b2.use MessageNotCreated
+          end
+          end
+        end
+      end
+
       def self.action_list_id
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
@@ -164,6 +185,7 @@ module VagrantPlugins
       autoload :PowerOn, action_root.join("power_on")
       autoload :ReadSSHInfo, action_root.join("read_ssh_info")
       autoload :ReadState, action_root.join("read_state")
+      autoload :Reinstall, action_root.join("reinstall")
       autoload :Reset, action_root.join("reset")
       autoload :RunInstance, action_root.join("run_instance")
       autoload :SyncFolders, action_root.join("sync_folders")

--- a/lib/vagrant-sakura/action/reinstall.rb
+++ b/lib/vagrant-sakura/action/reinstall.rb
@@ -1,0 +1,112 @@
+require 'vagrant/util/retryable'
+
+require 'vagrant-sakura/driver/api'
+#require 'vagrant-sakura/util/timer'
+require 'log4r'
+
+module VagrantPlugins
+  module Sakura
+    module Action
+      class Reinstall
+        include Vagrant::Util::Retryable
+
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_sakura::action::run_instance")
+        end
+
+        def call(env)
+          disk_source_archive = env[:machine].provider_config.disk_source_archive
+          os_type = env[:machine].provider_config.os_type
+          sshkey_id = env[:machine].provider_config.sshkey_id
+          public_key_path = env[:machine].provider_config.public_key_path
+          use_insecure_key = env[:machine].provider_config.use_insecure_key
+          startup_scripts = env[:machine].provider_config.startup_scripts
+
+          api = env[:sakura_api]
+          serverid = env[:machine].id
+          diskid = env[:machine].provider_config.disk_id
+
+          unless env[:machine].provider_config.disk_id
+            begin
+              response = api.get("/server/#{serverid}")
+            rescue Driver::NotFoundError
+              raise 'server not found'
+            end
+            diskid = response["Server"]["Disks"][0]["ID"]
+          end
+
+          env[:ui].info(I18n.t("vagrant_sakura.reinstalling_disk"))
+          env[:ui].info(" -- Target Disk ID: #{diskid}") if os_type
+          env[:ui].info(" -- Disk Source OS Type: #{os_type}") if os_type
+          env[:ui].info(" -- Disk Source Archive: #{disk_source_archive}")
+          env[:ui].info(" -- Startup Scripts: #{startup_scripts.map {|item| item["ID"]}}") unless startup_scripts.empty?
+
+         data = {
+             "Disk" => {
+                 "SourceArchive" => {
+                     "ID" => disk_source_archive
+                 },
+             }
+         }
+         response = api.put("/disk/#{diskid}/install", data)
+
+         while true
+           response = api.get("/disk/#{diskid}")
+           case response["Disk"]["Availability"]
+           when "available"
+             break
+           when "migrating"
+             migrated = response["Disk"]["MigratedMB"]
+             size = response["Disk"]["SizeMB"]
+             env[:ui].info("Disk #{diskid} is migrating (#{migrated}/#{size})")
+           else
+             status = presponse["Disk"]["Availability"]
+             env[:ui].info("Disk #{diskid} is #{status}")
+           end
+           sleep 3
+         end
+
+          data = {
+            "UserSubnet" => {},
+            "Notes" => startup_scripts
+          }
+          if sshkey_id
+            data["SSHKey"] = { "ID" => sshkey_id }
+          elsif public_key_path
+            data["SSHKey"] = { "PublicKey" => File.read(public_key_path) }
+          elsif use_insecure_key
+            pubkey = Vagrant.source_root.join("keys", "vagrant.pub").read.chomp
+            data["SSHKey"] = { "PublicKey" => pubkey }
+          else
+            raise 'failsafe'
+          end
+
+          response = api.put("/disk/#{diskid}/config", data)
+          # Config
+
+          response = api.put("/server/#{serverid}/power")
+          # Power On
+
+          if !env[:interrupted]
+            # Wait for SSH to be ready.
+            env[:ui].info(I18n.t("vagrant_sakura.waiting_for_ssh"))
+            while true
+              break if env[:interrupted]
+              break if env[:machine].communicate.ready?
+              sleep 2
+            end
+
+            #@logger.info("Time for SSH ready: #{env[:metrics]["instance_ssh_time"]}")
+
+            # Ready and booted!
+            env[:ui].info(I18n.t("vagrant_sakura.ready"))
+          end
+
+          @app.call(env)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-sakura/command_list_id.rb
+++ b/lib/vagrant-sakura/command_list_id.rb
@@ -1,6 +1,6 @@
 module VagrantPlugins
   module Sakura
-    class Command < Vagrant.plugin(2, :command)
+    class CommandListId < Vagrant.plugin(2, :command)
       def self.synopsis
         "query Sakura for available archives and server plans"
       end

--- a/lib/vagrant-sakura/command_reinstall.rb
+++ b/lib/vagrant-sakura/command_reinstall.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module Sakura
+    class CommandReinstall < Vagrant.plugin(2, :command)
+      def self.synopsis
+        "Reinstall Sakura cloud disk"
+      end
+
+      def execute
+        with_target_vms(nil, { :provider => "sakura" }) do |vm|
+          vm.action(:reinstall)
+        end
+        0
+      end
+    end
+  end
+end

--- a/lib/vagrant-sakura/plugin.rb
+++ b/lib/vagrant-sakura/plugin.rb
@@ -23,9 +23,14 @@ module VagrantPlugins
         Provider
       end
 
+      command(:'sakura-reinstall') do
+        require_relative "command_reinstall"
+        CommandReinstall
+      end
+
       command(:'sakura-list-id') do
-        require_relative "command"
-        Command
+        require_relative "command_list_id"
+        CommandListId
       end
 
       def self.setup_i18n

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,6 +8,8 @@ en:
       Warning! You are using insecure default key to login to the server on
       Sakura-no-cloud.  The key is publicly available (bundled in Vagrant
       distribution) so malicious people can login to your server.
+    reinstalling_disk: |-
+      Re-installing a disk with the following settings...
     down: |-
       The server is down.
     not_created: |-


### PR DESCRIPTION
To fix #25

ディスクの再インストールを行うためのコマンド `sakura-reinstall`を追加。

- サーバが起動している場合はシャットダウンを行う
- 指定のアーカイブ(os_type含む)からディスクの再インストール(`PUT /disk/:diskid/install`)
- サーバが作成されていない場合はメッセージを表示して何もしない
- ctrl-cなどで処理が中断された場合の後処理は特に行わない(upなどではサーバの削除処理が行われる)

