### PR TITLE
デフォルトでのパスワード認証無効化

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ $ vagrant sakura-list-id
 - ``server_plan`` - 作成するサーバのプラン ID
 - ``packet_filter`` - 作成するサーバに適用するパケットフィルタ ID
 - ``startup_scripts`` - 作成するサーバに適用するスタートアップスクリプト ID(リスト)
+- ``enable_pw_auth`` - パスワード認証の有効化(デフォルト: `false`)
 - ``tags`` - 作成するサーバ/ディスクのタグ(リスト)
 - ``description`` - 作成するサーバ/ディスクの説明
 - ``sshkey_id`` - サーバへのログインに利用する SSH 公開鍵のリソース ID

--- a/lib/vagrant-sakura/action/reinstall.rb
+++ b/lib/vagrant-sakura/action/reinstall.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
           use_insecure_key = env[:machine].provider_config.use_insecure_key
+          enable_pw_auth = env[:machine].provider_config.enable_pw_auth
           startup_scripts = env[:machine].provider_config.startup_scripts
 
           api = env[:sakura_api]
@@ -68,8 +69,9 @@ module VagrantPlugins
          end
 
           data = {
-            "UserSubnet" => {},
-            "Notes" => startup_scripts
+              "UserSubnet" => {},
+              "Notes" => startup_scripts,
+              "DisablePWAuth" => !enable_pw_auth
           }
           if sshkey_id
             data["SSHKey"] = { "ID" => sshkey_id }

--- a/lib/vagrant-sakura/action/run_instance.rb
+++ b/lib/vagrant-sakura/action/run_instance.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
           sshkey_id = env[:machine].provider_config.sshkey_id
           public_key_path = env[:machine].provider_config.public_key_path
           use_insecure_key = env[:machine].provider_config.use_insecure_key
+          enable_pw_auth = env[:machine].provider_config.enable_pw_auth
           packet_filter = env[:machine].provider_config.packet_filter.to_s
           startup_scripts = env[:machine].provider_config.startup_scripts
           tags = env[:machine].provider_config.tags
@@ -116,7 +117,8 @@ module VagrantPlugins
 
           data = {
             "UserSubnet" => {},
-            "Notes" => startup_scripts
+            "Notes" => startup_scripts,
+            "DisablePWAuth" => !enable_pw_auth
           }
           if sshkey_id
             data["SSHKey"] = { "ID" => sshkey_id }

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -61,6 +61,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :use_insecure_key
 
+      # Enable password auth to connecting via ssh.
+      #
+      # @return [Boolean]
+      attr_accessor :enable_pw_auth
+
       # The packet filter ID of the server's first NIC.
       #
       # @return [String]
@@ -101,6 +106,7 @@ module VagrantPlugins
         @server_plan         = UNSET_VALUE
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
+        @enable_pw_auth      = UNSET_VALUE
         @packet_filter       = UNSET_VALUE
         @startup_scripts     = UNSET_VALUE
         @zone_id             = UNSET_VALUE
@@ -167,6 +173,7 @@ module VagrantPlugins
         @sshkey_id = nil if @sshkey_id == UNSET_VALUE
 
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
+        @enable_pw_auth = false if @enable_pw_auth == UNSET_VALUE
 
         @packet_filter = "" if @packet_filter == UNSET_VALUE
 


### PR DESCRIPTION
To fix #20 

サーバ作成時にSSH接続時のパスワード認証を無効化する。
設定にはディスクの修正機能を用いる。

Vagrantfileにて`enable_pw_auth`をtrueにすることでこの挙動を変更可能。
