### PR TITLE
新ディスクの修正APIの利用

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ $ vagrant sakura-list-id
 
 - ``disk_source_archive`` - サーバで利用するディスクのベースとするアーカイブのID (※`os_type`とは同時に指定できません)
 - ``server_name`` - サーバ名
-- ``server_plan`` - 作成するサーバのプラン ID
+- ``server_plan`` - 作成するサーバのプラン ID(**非推奨** 代わりに`server_core`と`server_memory`を利用してください)
+- ``server_core`` - 作成するサーバのコア数(デフォルト: `1`)
+- ``server_memory`` - 作成するサーバのメモリサイズ(GB単位、デフォルト: `1`)
 - ``packet_filter`` - 作成するサーバに適用するパケットフィルタ ID
 - ``startup_scripts`` - 作成するサーバに適用するスタートアップスクリプト ID(リスト)
 - ``enable_pw_auth`` - パスワード認証の有効化(デフォルト: `false`)

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -47,9 +47,22 @@ module VagrantPlugins
       attr_accessor :server_name
 
       # The Plan ID of the server.
-      # 
+      #
+      # @deprecated Use {#server_core} and {#server_memory} instead.
       # @return [Fixnum]
       attr_accessor :server_plan
+
+      # The number of cores.
+      #
+      # @return [Fixnum]
+      attr_accessor :server_core
+
+      # The number of memories.
+      # unit: GB
+      #
+      # @deprecated Use {#server_core} and {#server_memory} instead.
+      # @return [Fixnum]
+      attr_accessor :server_memory
 
       # The resource ID of the SSH public key to login the server.
       # 
@@ -104,6 +117,8 @@ module VagrantPlugins
         @public_key_path     = UNSET_VALUE
         @server_name         = UNSET_VALUE
         @server_plan         = UNSET_VALUE
+        @server_core         = UNSET_VALUE
+        @server_memory       = UNSET_VALUE
         @sshkey_id           = UNSET_VALUE
         @use_insecure_key    = UNSET_VALUE
         @enable_pw_auth      = UNSET_VALUE
@@ -167,7 +182,13 @@ module VagrantPlugins
         end
 
         if @server_plan == UNSET_VALUE
-          @server_plan = 1001  # 1Core-1GB - cheapest
+          @server_plan = nil
+        end
+        if @server_core == UNSET_VALUE
+          @server_core = 1
+        end
+        if @server_memory == UNSET_VALUE
+          @server_memory = 1
         end
 
         @sshkey_id = nil if @sshkey_id == UNSET_VALUE


### PR DESCRIPTION
サーバ作成時のディスクの修正関連パラメータの指定をディスク作成時に行うようにする。

see: https://cloud-news.sakura.ad.jp/2018/10/11/modifydisk-enhanced/

これに合わせ、サーバプランにてコア数/メモリ数を個別に指定可能にする。

旧: `server_plan`パラメータにプランIDを指定
新: `server_core`と`server_memory`パラメータで指定

なお、当面は`server_plan`での指定も可能とする。
`server_plan`と`server_core`&`server_memory`の組み合わせが同時に指定されていた場合は
`server_plan`を優先とする。

いずれも未指定の場合は以下のデフォルト値を用いる。

`server_core`: デフォルト 1
`server_memory`: デフォルト 1