### PR TITLE
os_typeバリデーション修正

### DIFF
--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -234,8 +234,10 @@ module VagrantPlugins
           errors << I18n.t("vagrant_sakura.config.need_ssh_key_config")
         end
 
-        if not VagrantPlugins::Sakura::OSType::os_types.include? @os_type
-          errors << I18n.t("vagrant_sakura.config.need_valid_os_type")
+        if disk_source_mode == :os_type
+          if not VagrantPlugins::Sakura::OSType::os_types.include? @os_type
+            errors << I18n.t("vagrant_sakura.config.need_valid_os_type")
+          end
         end
 
         { "Sakura Provider" => errors }

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -251,6 +251,22 @@ module VagrantPlugins
                 },
                 "expect" => false
             },
+
+            "os_type is empty with archive_id" => {
+                "config" => {
+                    "use_insecure_key" => true,
+                    "disk_source_archive" => "999999999999"
+                },
+                "expect" => true
+            },
+
+            "os_type is empty with disk_id" => {
+                "config" => {
+                    "use_insecure_key" => true,
+                    "disk_id" => "999999999999"
+                },
+                "expect" => true
+            },
         }
 
         cases.map do |name, c|


### PR DESCRIPTION
`disk_source_archive` または `disk_id`指定時に以下の`os_type`必須エラーが出る問題を修正。

```console
Sakura Provider:
* You must set valid os_type value.
```