### PR TITLE
Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ $ vagrant sakura-list-id
 |指定可能な値|SSHユーザー名|Vagrantfileの例|備考|
 |---|---|:---:|---|
 |`ubuntu`(デフォルト)|`ubuntu`| [example](examples/ubuntu.md) | - |
+|`ubuntu-20.04`|`ubuntu`| - | - |
 |`ubuntu-18.04`|`ubuntu`| - | - |
 |`ubuntu-16.04`|`ubuntu`| - | - |
 |`centos`|`root`| [example](examples/centos.md) | - |

--- a/lib/vagrant-sakura/os_type.rb
+++ b/lib/vagrant-sakura/os_type.rb
@@ -17,6 +17,9 @@ module VagrantPlugins
           "ubuntu" => {
               "Tags.Name" => [%w(current-stable distro-ubuntu)]
           },
+          "ubuntu-20.04" => {
+              "Tags.Name" => [%w(ubuntu-20.04-latest)]
+          },
           "ubuntu-18.04" => {
               "Tags.Name" => [%w(ubuntu-18.04-latest)]
           },


### PR DESCRIPTION
`os_type`に`ubuntu-20.04`を指定可能にする。