### PR TITLE
Remove ruby-2.3.7 from test targets on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
     packages:
     - bsdtar
 rvm:
-- 2.3.7
 - 2.4.4
 - 2.5.0
 - 2.5.1


### PR DESCRIPTION
以下のようなエラーがTravisCI上で出ているためテスト対象からruby-2.3.7を除外する。

    vagrant-2.2.7 requires ruby version < 2.7, ~> 2.4, which is incompatible with 265the current version, ruby 2.3.7p456
